### PR TITLE
Jans last check

### DIFF
--- a/materials/study_02/consent-form.md
+++ b/materials/study_02/consent-form.md
@@ -1,6 +1,6 @@
 ## Description
 
-If you choose to participate, you will take part in a study about "Validating statistical methods to detect (potential) data fabrication". If you participate, you will be asked to fabricate research results of the Stroop task and be interviewed about how you fabricated the interview.
+If you choose to participate, you will take part in a study about "Validating statistical methods to detect (potential) data fabrication". If you participate, you will be asked to fabricate research results of the Stroop task and be interviewed about how you fabricated the data.
 
 ## Benefits
 
@@ -10,7 +10,7 @@ Your participation will help us investigate the performance of statistical metho
 
 ## Risks/discomforts
 
-Fabricating the data will take at least 30 minutes, but how long you spend on it is at your discretion. The face-to-face interview will take approximately 45 minutes and will be audio-recorded. There is a small risk that you may become uncomfortable during the study given the unethical nature of the behavior that we request you to perform in this controlled setting. If any feelings of discomfort emerge you are free to contact the principal investigator with any questions or concerns using the email address listed at the bottom of this consent form. This study has been approved by the Tilburg University Psychological Ethics Committee (reference EC-2015.50).
+ Fabricating the data will take at least 30 minutes, but beyond that you can decide yourself how long you spend on it. The face-to-face interview will take approximately 45 minutes and will be audio-recorded. There is a small risk that you may become uncomfortable during the study given the unethical nature of the behavior that we request you to perform in this controlled setting. If any feelings of discomfort emerge you are free to contact the principal investigator with any questions or concerns using the email address listed at the bottom of this consent form. This study has been approved by the Tilburg University Psychological Ethics Committee (reference EC-2015.50).
 
 ## Confidentiality
 

--- a/materials/study_02/instructions.md
+++ b/materials/study_02/instructions.md
@@ -8,7 +8,7 @@ In the Stroop task, participants are asked to determine the color a word is pres
 
 ## Hypotheses
 
-Your task is to confirm the existence of a Stroop effect with fabricated data, while attempting to cover up the data fabrication by making them look as genuine as possible. In other words, the hypothesis is that there is an effect of congruency on the response latencies in the Stroop task, such that responses in the incongruent condition are slower than in the congruent condition.
+Your task is to confirm the existence of a Stroop effect with fabricated data, while attempting to cover up the data fabrication by making them look as genuine as possible. In other words, the hypothesis is that there is an effect of congruency on the response latencies in the Stroop task, such that responses in the incongruent condition are on average slower than in the congruent condition.
 
 ## Fabrication instructions
 
@@ -16,11 +16,11 @@ We require you to fabricate the mean and standard deviation of the response late
 
 At the bottom of this page, a link is provided to a spreadsheet in which you have to fill out your fabricated data. 
 
-Your task is to fabricate the mean and standard deviation of the response latencies in milliseconds (i.e., 1 second = 1000 milliseconds) for congruent and incongruent conditions. How you decide to fabricate these data is at your discretion. 
+Your task is to fabricate the mean and standard deviation of the response latencies in milliseconds (i.e., 1 second = 1000 milliseconds) for each person for both the congruent condition and the incongruent condition. How you decide to fabricate these data is fully in your own hands. 
 
-The congruent response latencies and their standard deviations are depicted in the spreadsheet in green. 
+The means of the congruent response latencies and their standard deviations are depicted in the spreadsheet in green. 
 
-The yellow cells depict incongruent response latencies. 
+The yellow cells depict the corresponding statistics for incongruent response latencies. 
 
 Each row depicts the data for one participant. 
 
@@ -38,17 +38,20 @@ The spreadsheet automatically calculates and displays the test statistics (t-val
 
 ## Schedule the face-to-face interview
 
-Now, we would like to request you to plan an interview with research assistant Jan. In order to facilitate the planning of the face-to-face interviews throughout the Netherlands and Belgium, we would like to ask you to suggest several options (at least three) in his calendar via Doodle.com with the address where the interview would take place. 
+Now, we would like to request you to plan an interview with research assistant Jan. In order to facilitate the planning of the face-to-face interviews throughout the Netherlands and Belgium, we would like to ask you to suggest several options (at least three) in his calendar via Doodle.com with the address where the interview would take place. Note that you can choose the address as long as it is within the Netherlands or Belgium.
 
 Multiple suggestions are a necessity, given travel time by public transport has to be taken into account. In the case that the suggestions are not physically possible for Jan, he will contact you to try and reschedule.
 
-Please visit the link below to schedule the interview and return to this page to continue (do not close this window).
+Please visit the link below to schedule the interview and return to this page to continue (**do not close this window**).
 
  - [ ] [Schedule the interview here](http://doodle.com/jangvoelkel)
 
+Please confirm below that you have suggested at least three meeting possibilities via the link provided above.
+- [ ] I confirm that I have suggested at least three meeting possibilities.
+
 <!-- force response on this page -->
 
-## End online part
+## End of survey message
 
 Thank you very much for wanting to participate in our study. We will finalize the scheduling of the interview as soon as possible. You are free to work on fabricating the Stroop data until the face-to-face interview takes place.
 


### PR DESCRIPTION
I thought I incorporated comments on the commit but they aren't shown here.

So, every change I did here I also did in qualtrics. So if you dislike a change, please reverse it in qualtrics as well.
I changed terms with "discretion". I don't think it is wrong, but as it also means that you remain quiet about something, I thought it is better to use other expressions to prevent misunderstandings when we ask about for instance how long it took them in the interview.

Probably most importantly:
- The download of the instructions does not work (I also think it is better if the name of the file does not contain sth with "git" so that they do not search for this project
- The download of the template does work, but there are errors in the spreadsheet (see issue)
